### PR TITLE
feat(mocker): add TypedMocker class for pytest-mock integration

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1064,7 +1064,7 @@ class TestNestedMock:
 | T103 | Claude | DONE | typed_mock 팩토리 함수 완료 |
 | T104 | Claude | DONE | 공개 API 정의 완료 |
 | T105 | Claude | DONE | 기본 타입 체커 호환성 검증 완료 |
-| T200 | - | BACKLOG | |
+| T200 | Claude | DONE | TypedMocker 클래스 구현 완료 |
 | T201 | - | BACKLOG | |
 | T202 | - | BACKLOG | |
 | T203 | - | BACKLOG | |

--- a/src/typed_pytest/__init__.py
+++ b/src/typed_pytest/__init__.py
@@ -15,6 +15,7 @@ Usage:
 from typed_pytest._factory import typed_mock
 from typed_pytest._method import AsyncMockedMethod, MockedMethod
 from typed_pytest._mock import TypedMock
+from typed_pytest._mocker import TypedMocker
 from typed_pytest._protocols import AsyncMockProtocol, MockProtocol
 from typed_pytest._version import __version__
 
@@ -25,6 +26,7 @@ __all__ = [
     "MockProtocol",
     "MockedMethod",
     "TypedMock",
+    "TypedMocker",
     "__version__",
     "typed_mock",
 ]

--- a/src/typed_pytest/_mocker.py
+++ b/src/typed_pytest/_mocker.py
@@ -1,0 +1,182 @@
+"""
+TypedMocker 클래스.
+
+pytest-mock의 MockerFixture를 래핑하여 타입 안전한 mock 기능을 제공합니다.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
+
+from typed_pytest._factory import typed_mock
+from typed_pytest._method import MockedMethod
+
+
+if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
+    from pytest_mock import MockerFixture
+
+    from typed_pytest._mock import TypedMock
+
+
+T = TypeVar("T")
+
+
+class TypedMocker:
+    """pytest-mock의 MockerFixture를 확장한 타입 안전 모커.
+
+    MockerFixture의 기능을 래핑하여 타입 안전한 mock, patch, spy를 제공합니다.
+
+    Usage:
+        >>> def test_example(mocker: MockerFixture):
+        ...     typed_mocker = TypedMocker(mocker)
+        ...     mock_service = typed_mocker.mock(UserService)
+        ...     mock_service.get_user.return_value = {"id": 1}
+        ...     assert mock_service.get_user(1) == {"id": 1}
+
+    Example:
+        mock() 사용:
+            >>> typed_mocker = TypedMocker(mocker)
+            >>> mock_service = typed_mocker.mock(UserService)
+            >>> mock_service.get_user.return_value = {"id": 1}
+
+        patch() 사용:
+            >>> mock = typed_mocker.patch("app.services.UserService", new=UserService)
+            >>> mock.get_user.return_value = {"id": 1}
+
+        spy() 사용:
+            >>> service = UserService()
+            >>> spy = typed_mocker.spy(service, "get_user")
+            >>> service.get_user(1)
+            >>> spy.assert_called_once_with(1)
+
+    Note:
+        TypedMocker가 제공하지 않는 기능은 `mocker` 속성을 통해
+        원본 MockerFixture에 접근하여 사용할 수 있습니다.
+    """
+
+    __slots__ = ("_mocker",)
+
+    def __init__(self, mocker: MockerFixture) -> None:
+        """TypedMocker 인스턴스를 생성합니다.
+
+        Args:
+            mocker: pytest-mock의 MockerFixture 인스턴스.
+        """
+        self._mocker = mocker
+
+    def mock(self, cls: type[T], /, **kwargs: Any) -> TypedMock[T]:
+        """타입 안전한 Mock 객체를 생성합니다.
+
+        기존 typed_mock() 팩토리 함수를 재사용합니다.
+
+        Args:
+            cls: Mock으로 만들 원본 클래스.
+            **kwargs: typed_mock()에 전달할 추가 인자
+                (spec_set, strict, name 등).
+
+        Returns:
+            원본 클래스의 타입 정보를 가진 TypedMock 인스턴스.
+
+        Example:
+            >>> mock_service = typed_mocker.mock(UserService)
+            >>> mock_service.get_user.return_value = {"id": 1}
+            >>> mock_service.get_user(1)
+            {'id': 1}
+        """
+        return typed_mock(cls, **kwargs)
+
+    @overload
+    def patch(
+        self,
+        target: str,
+        *,
+        new: type[T],
+        **kwargs: Any,
+    ) -> TypedMock[T]: ...
+
+    @overload
+    def patch(
+        self,
+        target: str,
+        **kwargs: Any,
+    ) -> MagicMock: ...
+
+    def patch(
+        self,
+        target: str,
+        *,
+        new: type[Any] | None = None,
+        **kwargs: Any,
+    ) -> TypedMock[Any] | MagicMock:
+        """타입 안전한 patch.
+
+        new 파라미터에 타입이 지정되면 TypedMock[T]를 반환합니다.
+        지정되지 않으면 기존 MagicMock을 반환합니다.
+
+        Note:
+            이 메소드는 컨텍스트 매니저가 아닌 직접 mock을 반환합니다.
+            pytest-mock의 mocker.patch()는 테스트 종료 시 자동으로 정리됩니다.
+
+        Args:
+            target: patch 대상 (모듈.클래스 형식).
+            new: Mock의 spec으로 사용할 클래스 (선택).
+            **kwargs: mocker.patch()에 전달할 추가 인자.
+
+        Returns:
+            TypedMock[T] (new 지정 시) 또는 MagicMock.
+
+        Example:
+            new 타입 지정:
+                >>> mock = typed_mocker.patch(
+                ...     "app.services.UserService",
+                ...     new=UserService,
+                ... )
+                >>> mock.get_user.return_value = {"id": 1}
+
+            타입 미지정 (기존 동작):
+                >>> mock = typed_mocker.patch("app.services.UserService")
+                >>> mock.return_value = {"id": 1}
+        """
+        if new is not None:
+            mock_instance = typed_mock(new)
+            return self._mocker.patch(target, mock_instance, **kwargs)
+        return cast("MagicMock", self._mocker.patch(target, **kwargs))
+
+    def spy(self, obj: object, name: str) -> MockedMethod[..., Any]:
+        """실제 객체의 메소드를 spy합니다.
+
+        원본 메소드의 동작을 유지하면서 호출을 추적합니다.
+
+        Args:
+            obj: spy할 객체 인스턴스.
+            name: spy할 메소드 이름.
+
+        Returns:
+            MockedMethod로 래핑된 spy 객체.
+
+        Example:
+            >>> service = UserService()
+            >>> spy = typed_mocker.spy(service, "get_user")
+            >>> service.get_user(1)  # 원본 메소드 실행
+            >>> spy.assert_called_once_with(1)
+        """
+        spy_mock = self._mocker.spy(obj, name)
+        return MockedMethod(spy_mock)
+
+    @property
+    def mocker(self) -> MockerFixture:
+        """원본 MockerFixture에 접근합니다.
+
+        TypedMocker가 제공하지 않는 기능이 필요할 때 사용합니다.
+        (예: resetall(), stopall(), stub(), patch.dict() 등)
+
+        Returns:
+            원본 MockerFixture 인스턴스.
+
+        Example:
+            >>> stub = typed_mocker.mocker.stub(name="callback")
+            >>> stub.return_value = "stubbed"
+        """
+        return self._mocker

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -177,13 +177,16 @@ class TestVersionInfo:
 class TestBackwardsCompatibility:
     """향후 호환성 테스트."""
 
-    def test_future_exports_commented(self) -> None:
-        """Phase 2 exports가 아직 추가되지 않았는지 확인."""
-        # Phase 2 기능은 아직 구현되지 않음
-        assert not hasattr(typed_pytest, "TypedMocker")
+    def test_phase2_exports_available(self) -> None:
+        """Phase 2 exports가 추가되었는지 확인 (T200 완료)."""
+        # T200: TypedMocker 클래스 구현 완료
+        assert hasattr(typed_pytest, "TypedMocker")
+        # typed_mocker fixture는 T201에서 구현 예정
         assert not hasattr(typed_pytest, "typed_mocker")
 
-    def test_phase2_not_in_all(self) -> None:
-        """Phase 2 exports가 __all__에 없는지 확인."""
-        assert "TypedMocker" not in typed_pytest.__all__
+    def test_phase2_in_all(self) -> None:
+        """Phase 2 exports가 __all__에 포함되었는지 확인."""
+        # T200: TypedMocker 클래스
+        assert "TypedMocker" in typed_pytest.__all__
+        # T201: typed_mocker fixture는 아직 미구현
         assert "typed_mocker" not in typed_pytest.__all__

--- a/tests/unit/test_typed_mocker.py
+++ b/tests/unit/test_typed_mocker.py
@@ -1,0 +1,283 @@
+"""TypedMocker 클래스 테스트."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.fixtures.sample_classes import ProductRepository, UserService
+from typed_pytest._method import MockedMethod
+from typed_pytest._mock import TypedMock
+from typed_pytest._mocker import TypedMocker
+
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+class TestTypedMockerCreation:
+    """TypedMocker 생성 테스트."""
+
+    def test_creation_with_mocker(self, mocker: MockerFixture) -> None:
+        """MockerFixture로 TypedMocker 생성."""
+        typed_mocker = TypedMocker(mocker)
+
+        assert typed_mocker is not None
+
+    def test_mocker_property_returns_original(self, mocker: MockerFixture) -> None:
+        """mocker 속성이 원본 MockerFixture를 반환하는지 확인."""
+        typed_mocker = TypedMocker(mocker)
+
+        assert typed_mocker.mocker is mocker
+
+
+class TestTypedMockerMock:
+    """TypedMocker.mock() 메소드 테스트."""
+
+    def test_mock_returns_typed_mock(self, mocker: MockerFixture) -> None:
+        """mock()이 TypedMock을 반환하는지 확인."""
+        typed_mocker = TypedMocker(mocker)
+
+        mock = typed_mocker.mock(UserService)
+
+        assert isinstance(mock, TypedMock)
+
+    def test_mock_preserves_type_info(self, mocker: MockerFixture) -> None:
+        """mock()이 타입 정보를 보존하는지 확인."""
+        typed_mocker = TypedMocker(mocker)
+
+        mock = typed_mocker.mock(UserService)
+
+        assert mock.typed_class is UserService
+
+    def test_mock_has_original_methods(self, mocker: MockerFixture) -> None:
+        """mock이 원본 클래스의 메소드를 가지는지 확인."""
+        typed_mocker = TypedMocker(mocker)
+
+        mock = typed_mocker.mock(UserService)
+
+        assert hasattr(mock, "get_user")
+        assert hasattr(mock, "create_user")
+        assert hasattr(mock, "delete_user")
+
+    def test_mock_with_spec_set(self, mocker: MockerFixture) -> None:
+        """mock()이 spec_set 옵션을 전달하는지 확인."""
+        typed_mocker = TypedMocker(mocker)
+
+        mock = typed_mocker.mock(UserService, spec_set=True)
+
+        with pytest.raises(AttributeError):
+            _ = mock.nonexistent_method
+
+    def test_mock_with_name(self, mocker: MockerFixture) -> None:
+        """mock()이 name 옵션을 전달하는지 확인."""
+        typed_mocker = TypedMocker(mocker)
+
+        mock = typed_mocker.mock(UserService, name="test_mock")
+
+        assert "test_mock" in repr(mock)
+
+    def test_mock_method_call_works(self, mocker: MockerFixture) -> None:
+        """mock된 메소드 호출이 동작하는지 확인."""
+        typed_mocker = TypedMocker(mocker)
+        mock = typed_mocker.mock(UserService)
+        mock.get_user.return_value = {"id": 1, "name": "Test"}
+
+        result = mock.get_user(1)
+
+        assert result == {"id": 1, "name": "Test"}
+        mock.get_user.assert_called_once_with(1)
+
+
+class TestTypedMockerPatch:
+    """TypedMocker.patch() 메소드 테스트."""
+
+    def test_patch_with_type_returns_typed_mock(self, mocker: MockerFixture) -> None:
+        """new 타입 지정 시 TypedMock을 반환하는지 확인."""
+        typed_mocker = TypedMocker(mocker)
+
+        mock = typed_mocker.patch(
+            "tests.fixtures.sample_classes.UserService",
+            new=UserService,
+        )
+
+        assert isinstance(mock, TypedMock)
+
+    def test_patch_with_type_preserves_type_info(self, mocker: MockerFixture) -> None:
+        """patch가 타입 정보를 보존하는지 확인."""
+        typed_mocker = TypedMocker(mocker)
+
+        mock = typed_mocker.patch(
+            "tests.fixtures.sample_classes.UserService",
+            new=UserService,
+        )
+
+        assert mock.typed_class is UserService
+
+    def test_patch_without_type_returns_magicmock(self, mocker: MockerFixture) -> None:
+        """new 미지정 시 MagicMock을 반환하는지 확인."""
+        typed_mocker = TypedMocker(mocker)
+
+        mock = typed_mocker.patch("tests.fixtures.sample_classes.UserService")
+
+        # MagicMock이지만 TypedMock은 아님
+        assert hasattr(mock, "return_value")
+        assert not isinstance(mock, TypedMock)
+
+    def test_patch_replaces_target(self, mocker: MockerFixture) -> None:
+        """patch가 실제로 대상을 교체하는지 확인."""
+        typed_mocker = TypedMocker(mocker)
+        mock = typed_mocker.patch(
+            "tests.fixtures.sample_classes.UserService",
+            new=UserService,
+        )
+        mock.get_user.return_value = {"id": 999}
+
+        # 패치된 모듈에서 UserService 가져오기
+        from tests.fixtures import sample_classes  # noqa: PLC0415
+
+        # 패치된 클래스가 mock인지 확인
+        result = sample_classes.UserService.get_user(1)
+        assert result == {"id": 999}
+
+
+class TestTypedMockerSpy:
+    """TypedMocker.spy() 메소드 테스트."""
+
+    def test_spy_returns_mocked_method(self, mocker: MockerFixture) -> None:
+        """spy()가 MockedMethod를 반환하는지 확인."""
+        typed_mocker = TypedMocker(mocker)
+        service = UserService()
+
+        spy = typed_mocker.spy(service, "validate_email")
+
+        assert isinstance(spy, MockedMethod)
+
+    def test_spy_tracks_calls(self, mocker: MockerFixture) -> None:
+        """spy가 호출을 추적하는지 확인."""
+        typed_mocker = TypedMocker(mocker)
+        service = UserService()
+
+        spy = typed_mocker.spy(service, "validate_email")
+
+        # 실제 메소드 호출
+        result = service.validate_email("test@example.com")
+
+        # 원본 동작 확인
+        assert result is True
+
+        # 호출 추적 확인
+        spy.assert_called_once_with("test@example.com")
+
+    def test_spy_has_mock_attributes(self, mocker: MockerFixture) -> None:
+        """spy가 Mock 속성을 가지는지 확인."""
+        typed_mocker = TypedMocker(mocker)
+        service = UserService()
+
+        spy = typed_mocker.spy(service, "validate_email")
+
+        assert hasattr(spy, "call_count")
+        assert hasattr(spy, "called")
+        assert hasattr(spy, "call_args")
+
+    def test_spy_call_count(self, mocker: MockerFixture) -> None:
+        """spy가 호출 횟수를 추적하는지 확인."""
+        typed_mocker = TypedMocker(mocker)
+        service = UserService()
+
+        spy = typed_mocker.spy(service, "validate_email")
+
+        service.validate_email("a@b.com")
+        service.validate_email("c@d.com")
+
+        assert spy.call_count == 2
+
+
+class TestTypedMockerRealScenarios:
+    """TypedMocker 실제 사용 시나리오 테스트."""
+
+    def test_service_with_mocked_repository(self, mocker: MockerFixture) -> None:
+        """서비스-리포지토리 패턴 테스트."""
+        typed_mocker = TypedMocker(mocker)
+        mock_repo = typed_mocker.mock(ProductRepository)
+        mock_repo.find_by_id.return_value = None
+
+        result = mock_repo.find_by_id("P001")
+
+        assert result is None
+        mock_repo.find_by_id.assert_called_once_with("P001")
+
+    def test_multiple_mocks(self, mocker: MockerFixture) -> None:
+        """여러 mock 동시 사용."""
+        typed_mocker = TypedMocker(mocker)
+        mock_service = typed_mocker.mock(UserService)
+        mock_repo = typed_mocker.mock(ProductRepository)
+
+        mock_service.get_user.return_value = {"id": 1}
+        mock_repo.find_all.return_value = []
+
+        assert mock_service.get_user(1) == {"id": 1}
+        assert mock_repo.find_all() == []
+
+    def test_access_original_mocker_stub(self, mocker: MockerFixture) -> None:
+        """원본 mocker의 stub() 기능 접근 테스트."""
+        typed_mocker = TypedMocker(mocker)
+
+        # 원본 mocker의 기능 사용
+        stub = typed_mocker.mocker.stub(name="test_stub")
+        stub.return_value = "stubbed"
+
+        assert stub() == "stubbed"
+
+    def test_access_original_mocker_resetall(self, mocker: MockerFixture) -> None:
+        """원본 mocker의 resetall() 기능 접근 테스트."""
+        typed_mocker = TypedMocker(mocker)
+
+        # mocker.patch()로 생성된 mock은 resetall()로 리셋됨
+        mock = typed_mocker.mocker.patch("tests.fixtures.sample_classes.UserService")
+        mock.get_user(1)
+        assert mock.get_user.call_count == 1
+
+        # 원본 mocker의 resetall 사용
+        typed_mocker.mocker.resetall()
+
+        # 리셋 후 호출 횟수 확인
+        assert mock.get_user.call_count == 0
+
+    def test_side_effect_sequence(self, mocker: MockerFixture) -> None:
+        """side_effect 시퀀스 테스트."""
+        typed_mocker = TypedMocker(mocker)
+        mock = typed_mocker.mock(UserService)
+        mock.get_user.side_effect = [
+            {"id": 1, "name": "First"},
+            {"id": 2, "name": "Second"},
+        ]
+
+        assert mock.get_user(1) == {"id": 1, "name": "First"}
+        assert mock.get_user(2) == {"id": 2, "name": "Second"}
+
+    def test_side_effect_exception(self, mocker: MockerFixture) -> None:
+        """side_effect 예외 테스트."""
+        typed_mocker = TypedMocker(mocker)
+        mock = typed_mocker.mock(UserService)
+        mock.get_user.side_effect = ValueError("User not found")
+
+        with pytest.raises(ValueError, match="User not found"):
+            mock.get_user(999)
+
+
+class TestTypedMockerPublicAPI:
+    """TypedMocker 공개 API 테스트."""
+
+    def test_import_from_package(self) -> None:
+        """패키지에서 TypedMocker를 임포트할 수 있는지 확인."""
+        from typed_pytest import TypedMocker as ImportedTypedMocker  # noqa: PLC0415
+
+        assert ImportedTypedMocker is TypedMocker
+
+    def test_in_all(self) -> None:
+        """TypedMocker가 __all__에 포함되어 있는지 확인."""
+        import typed_pytest  # noqa: PLC0415
+
+        assert "TypedMocker" in typed_pytest.__all__


### PR DESCRIPTION
- Add TypedMocker class with mock(), patch(), spy() methods
- Support @overload for patch() return type inference
- Re-use typed_mock() factory for mock creation
- Add comprehensive unit tests (24 test cases)
- Ensure mypy/pyright strict mode compatibility
- Update public API exports (__all__)
- Update test_public_api.py for Phase 2 status

Closes T200

🤖 Generated with [Claude Code](https://claude.com/claude-code)