### PR TITLE
feat: Add recursive wildcard pattern (**) for package scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,10 +172,13 @@ You can configure `typed-pytest-generator` in your `pyproject.toml` file. This a
 ```toml
 [tool.typed-pytest-generator]
 # List of fully qualified class names to generate stubs for
-# Supports wildcard patterns: "module.*" matches all classes in the module
+# Supports wildcard patterns:
+#   - "module.*"  matches all classes in the module (non-recursive)
+#   - "module.**" matches all classes in the package recursively (includes submodules)
 targets = [
-    "myapp.services.*",                      # All classes in myapp.services
-    "myapp.repositories.ProductRepository",  # Specific class
+    "myapp.services.*",                      # All classes in myapp.services module
+    "myapp.repositories.**",                 # All classes in repositories and all submodules
+    "myapp.models.User",                     # Specific class
 ]
 
 # Output directory for generated stubs (default: "typed_pytest_stubs")
@@ -218,11 +221,14 @@ typed-pytest-generator -e myapp.services.SkipThis
 # Use a specific config file
 typed-pytest-generator -c /path/to/pyproject.toml
 
-# Use wildcard to match all classes in a module
+# Use wildcard to match all classes in a module (non-recursive)
 typed-pytest-generator -t "myapp.services.*"
 
+# Use recursive wildcard to match all classes in a package and submodules
+typed-pytest-generator -t "myapp.repositories.**"
+
 # Combine options
-typed-pytest-generator -t "myapp.services.*" -e myapp.services.Internal -o stubs -v
+typed-pytest-generator -t "myapp.repositories.**" -e myapp.repositories.Internal -o stubs -v
 ```
 
 #### IDE and Type Checker Setup

--- a/tests/fixtures/sample_package/__init__.py
+++ b/tests/fixtures/sample_package/__init__.py
@@ -1,0 +1,8 @@
+"""Sample package for testing recursive wildcard expansion."""
+
+
+class PackageLevelClass:
+    """A class defined at package level."""
+
+    def package_method(self) -> str:
+        return "package"

--- a/tests/fixtures/sample_package/module_a.py
+++ b/tests/fixtures/sample_package/module_a.py
@@ -1,0 +1,11 @@
+"""Module A in sample package."""
+
+
+class ClassA:
+    """Class A for testing."""
+
+    async def async_method_a(self, value: int) -> str:
+        return str(value)
+
+    def sync_method_a(self) -> list:
+        return []

--- a/tests/fixtures/sample_package/module_b.py
+++ b/tests/fixtures/sample_package/module_b.py
@@ -1,0 +1,8 @@
+"""Module B in sample package."""
+
+
+class ClassB:
+    """Class B for testing."""
+
+    def method_b(self, name: str) -> dict:
+        return {"name": name}

--- a/tests/fixtures/sample_package/subpackage/__init__.py
+++ b/tests/fixtures/sample_package/subpackage/__init__.py
@@ -1,0 +1,1 @@
+"""Subpackage for testing recursive wildcard expansion."""

--- a/tests/fixtures/sample_package/subpackage/deep_module.py
+++ b/tests/fixtures/sample_package/subpackage/deep_module.py
@@ -1,0 +1,11 @@
+"""Deep module in subpackage for testing recursive expansion."""
+
+
+class DeepClass:
+    """Class in a nested subpackage."""
+
+    async def deep_async_method(self, data: str) -> bool:
+        return True
+
+    def deep_sync_method(self) -> int:
+        return 42

--- a/tests/unit/test_recursive_wildcard.py
+++ b/tests/unit/test_recursive_wildcard.py
@@ -1,0 +1,85 @@
+"""Test recursive wildcard pattern expansion."""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+from typed_pytest_generator._generator import StubGenerator
+
+
+class TestRecursiveWildcardExpansion:
+    """Test ** pattern for recursive submodule scanning."""
+
+    def test_recursive_wildcard_finds_all_submodule_classes(self) -> None:
+        """** pattern should find classes in all submodules recursively."""
+        generator = StubGenerator(
+            targets=["tests.fixtures.sample_package.**"],
+            output_dir=Path(tempfile.mkdtemp()),
+        )
+
+        expanded = generator._expand_targets(generator.targets)  # noqa: SLF001
+
+        # Verify all expected classes are found
+        assert "tests.fixtures.sample_package.PackageLevelClass" in expanded
+        assert "tests.fixtures.sample_package.module_a.ClassA" in expanded
+        assert "tests.fixtures.sample_package.module_b.ClassB" in expanded
+        assert (
+            "tests.fixtures.sample_package.subpackage.deep_module.DeepClass" in expanded
+        )
+
+    def test_single_wildcard_does_not_find_submodule_classes(self) -> None:
+        """* pattern should NOT find classes in submodules."""
+        generator = StubGenerator(
+            targets=["tests.fixtures.sample_package.*"],
+            output_dir=Path(tempfile.mkdtemp()),
+        )
+
+        expanded = generator._expand_targets(generator.targets)  # noqa: SLF001
+
+        # Should only find classes from __init__.py
+        assert "tests.fixtures.sample_package.PackageLevelClass" in expanded
+
+        # Should NOT find classes from submodules
+        assert "tests.fixtures.sample_package.module_a.ClassA" not in expanded
+        assert "tests.fixtures.sample_package.module_b.ClassB" not in expanded
+        assert (
+            "tests.fixtures.sample_package.subpackage.deep_module.DeepClass"
+            not in expanded
+        )
+
+    def test_recursive_wildcard_generates_stubs(self) -> None:
+        """** pattern should generate stubs for all found classes."""
+        output_dir = Path(tempfile.mkdtemp())
+        try:
+            generator = StubGenerator(
+                targets=["tests.fixtures.sample_package.**"],
+                output_dir=output_dir,
+            )
+            generator.generate()
+
+            runtime_path = output_dir / "_runtime.py"
+            content = runtime_path.read_text()
+
+            # All classes should be in the generated stub
+            assert "class PackageLevelClass:" in content
+            assert "class ClassA:" in content
+            assert "class ClassB:" in content
+            assert "class DeepClass:" in content
+
+            # Async methods should be properly detected
+            assert "async def async_method_a" in content
+            assert "async def deep_async_method" in content
+        finally:
+            shutil.rmtree(output_dir)
+
+    def test_module_level_wildcard_works(self) -> None:
+        """* pattern on a module (not package) should find its classes."""
+        generator = StubGenerator(
+            targets=["tests.fixtures.sample_package.module_a.*"],
+            output_dir=Path(tempfile.mkdtemp()),
+        )
+
+        expanded = generator._expand_targets(generator.targets)  # noqa: SLF001
+
+        assert "tests.fixtures.sample_package.module_a.ClassA" in expanded
+        assert len(expanded) == 1


### PR DESCRIPTION
Add support for `**` pattern to recursively scan all submodules in a package:
- `myapp.repository.*` - scans only the module (non-recursive)
- `myapp.repository.**` - scans package and all submodules recursively

Uses pkgutil.walk_packages() for recursive module discovery.

Includes:
- New _expand_recursive() method for recursive scanning
- Test fixtures with nested package structure
- Updated README with pattern documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)